### PR TITLE
Update release notes and getting started links in VSIX manifest

### DIFF
--- a/src/T4Toolbox.vsix/source.extension.vsixmanifest
+++ b/src/T4Toolbox.vsix/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
     <MoreInfo>https://github.com/olegsych/T4Toolbox</MoreInfo>
     <License>License.txt</License>
     <GettingStartedGuide>https://github.com/olegsych/T4Toolbox/wiki/Getting-Started</GettingStartedGuide>
-    <ReleaseNotes>https://github.com/olegsych/T4Toolbox/wiki/Release-Notes</ReleaseNotes>
+    <ReleaseNotes>https://github.com/olegsych/T4Toolbox/releases</ReleaseNotes>
   </Metadata>
   <Installation InstalledByMsi="false">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />

--- a/src/T4Toolbox.vsix/source.extension.vsixmanifest
+++ b/src/T4Toolbox.vsix/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>Extends Text Templates with syntax colorization, error reporting, outlining, QuickInfo tooltips, statement completion, generation of multiple output files with source control integration, support for template parameters in Solution Explorer properties and more.</Description>
     <MoreInfo>https://github.com/olegsych/T4Toolbox</MoreInfo>
     <License>License.txt</License>
-    <GettingStartedGuide>https://github.com/olegsych/T4Toolbox/wiki/Getting-Started</GettingStartedGuide>
+    <GettingStartedGuide>http://olegsych.github.io/T4Toolbox/getting-started.html</GettingStartedGuide>
     <ReleaseNotes>https://github.com/olegsych/T4Toolbox/releases</ReleaseNotes>
   </Metadata>
   <Installation InstalledByMsi="false">


### PR DESCRIPTION
- Getting Started link now points to the GitHub pages web site. Wiki is too limited.
- Release Notes link now points to the GitHub releases page of the project.
