### PR TITLE
Downgrade .NET from v4.7 to v4.6 for backward compatibility

### DIFF
--- a/T4Toolbox.Common.props
+++ b/T4Toolbox.Common.props
@@ -7,7 +7,7 @@
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>$(MSBuildProjectName)</RootNamespace>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/src/T4Toolbox.DirectiveProcessors/packages.config
+++ b/src/T4Toolbox.DirectiveProcessors/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" developmentDependency="true" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" developmentDependency="true" userInstalled="true" />
 </packages>

--- a/src/T4Toolbox.TemplateAnalysis/packages.config
+++ b/src/T4Toolbox.TemplateAnalysis/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" userInstalled="true" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" userInstalled="true" developmentDependency="true" />
   <package id="YaccLexTools" version="0.2.2" targetFramework="net452" userInstalled="true" />
 </packages>

--- a/src/T4Toolbox.VisualStudio.Editor/packages.config
+++ b/src/T4Toolbox.VisualStudio.Editor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" userInstalled="true" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/src/T4Toolbox.VisualStudio/packages.config
+++ b/src/T4Toolbox.VisualStudio/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" developmentDependency="true" userInstalled="true" />
-  <package id="YaccLexTools" version="0.2.2" targetFramework="net45" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" developmentDependency="true" userInstalled="true" />
+  <package id="YaccLexTools" version="0.2.2" targetFramework="net452" userInstalled="true" />
 </packages>

--- a/src/T4Toolbox.vsix/source.extension.vsixmanifest
+++ b/src/T4Toolbox.vsix/source.extension.vsixmanifest
@@ -13,7 +13,7 @@
     <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7,)" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0,16.0)" />
   </Dependencies>
   <Assets>

--- a/src/T4Toolbox/packages.config
+++ b/src/T4Toolbox/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" developmentDependency="true" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" developmentDependency="true" userInstalled="true" />
 </packages>

--- a/test/T4Toolbox.TemplateAnalysis.Tests/packages.config
+++ b/test/T4Toolbox.TemplateAnalysis.Tests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="2.0.3" targetFramework="net47" userInstalled="true" />
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" userInstalled="true" developmentDependency="true" />
-  <package id="xunit" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.assert" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.core" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net47" />
-  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net47" userInstalled="true" developmentDependency="true" />
+  <package id="NSubstitute" version="2.0.3" targetFramework="net452" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" userInstalled="true" developmentDependency="true" />
+  <package id="xunit" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/test/T4Toolbox.Tests/packages.config
+++ b/test/T4Toolbox.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" developmentDependency="true" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" developmentDependency="true" userInstalled="true" />
 </packages>

--- a/test/T4Toolbox.VisualStudio.Editor.Tests/packages.config
+++ b/test/T4Toolbox.VisualStudio.Editor.Tests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="2.0.3" targetFramework="net47" userInstalled="true" />
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" userInstalled="true" developmentDependency="true" />
-  <package id="xunit" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.assert" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.core" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net47" userInstalled="true" />
-  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net47" />
-  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net47" userInstalled="true" developmentDependency="true" />
+  <package id="NSubstitute" version="2.0.3" targetFramework="net452" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" userInstalled="true" developmentDependency="true" />
+  <package id="xunit" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" userInstalled="true" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" userInstalled="true" developmentDependency="true" />
 </packages>

--- a/test/T4Toolbox.VisualStudio.IntegrationTests/packages.config
+++ b/test/T4Toolbox.VisualStudio.IntegrationTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" developmentDependency="true" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" developmentDependency="true" userInstalled="true" />
 </packages>

--- a/test/T4Toolbox.VisualStudio.Tests/packages.config
+++ b/test/T4Toolbox.VisualStudio.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="2.0.3" targetFramework="net47" userInstalled="true" />
-  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net47" developmentDependency="true" userInstalled="true" />
+  <package id="NSubstitute" version="2.0.3" targetFramework="net452" userInstalled="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" developmentDependency="true" userInstalled="true" />
 </packages>


### PR DESCRIPTION
Visual Studio 2017 is built with .NET 4.6. This change should allow T4 Toolbox to be installed without forcing installation of .NET 4.7.