### PR TITLE
Build in Visual Studio 2017 update 3 (15.3)

### DIFF
--- a/T4Toolbox.Common.props
+++ b/T4Toolbox.Common.props
@@ -43,13 +43,15 @@
     <DefineConstants>$(DefineConstants);SIGN_ASSEMBLY</DefineConstants>
   </PropertyGroup>
 
-  <!-- 
-    Set "Copy Local" assembly references to False by default. 
-    This avoids unnecessary copying of SDK assemblies to build output and 
-    prevents inclusion of unnecessary .dll files in the .vsix.
-  -->
+
   <ItemDefinitionGroup>
     <Reference>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <!-- 
+        Set "Copy Local" assembly references to False by default. 
+        This avoids unnecessary copying of SDK assemblies to build output and 
+        prevents inclusion of unnecessary .dll files in the .vsix.
+      -->
       <Private>False</Private>
     </Reference>
   </ItemDefinitionGroup>

--- a/src/T4Toolbox.VisualStudio/T4Toolbox.VisualStudio.csproj
+++ b/src/T4Toolbox.VisualStudio/T4Toolbox.VisualStudio.csproj
@@ -27,6 +27,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
     <Reference Include="Microsoft.VisualStudio.TextTemplating.15.0" />
     <Reference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0" />

--- a/src/T4Toolbox.VisualStudio/T4Toolbox.VisualStudio.csproj
+++ b/src/T4Toolbox.VisualStudio/T4Toolbox.VisualStudio.csproj
@@ -14,17 +14,11 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="EnvDTE">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="EnvDTE80">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="EnvDTE" />
+    <Reference Include="EnvDTE80" />
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.VisualStudio.Designer.Interfaces">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Designer.Interfaces" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Framework" />
@@ -47,9 +41,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="VSLangProj">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="VSLangProj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\T4Toolbox.DirectiveProcessors\T4Toolbox.DirectiveProcessors.csproj">

--- a/test/T4Toolbox.VisualStudio.IntegrationTests/IntegrationTest.cs
+++ b/test/T4Toolbox.VisualStudio.IntegrationTests/IntegrationTest.cs
@@ -48,7 +48,9 @@ namespace T4Toolbox.VisualStudio.IntegrationTests
         [AssemblyInitialize]
         public static void AssemblyInitialize(TestContext context)
         {
+#pragma warning disable 618
             ThreadHelper.Generic.Invoke(delegate
+#pragma warning restore 618
             {
                 CreateTestSolution();
                 UIThreadDispatcher = Dispatcher.CurrentDispatcher;
@@ -58,7 +60,9 @@ namespace T4Toolbox.VisualStudio.IntegrationTests
         [AssemblyCleanup]
         public static void AssemblyCleanup()
         {
+#pragma warning disable 618
             ThreadHelper.Generic.Invoke(DeleteTestSolution);
+#pragma warning restore 618
         }
 
         public void Dispose()

--- a/test/T4Toolbox.VisualStudio.IntegrationTests/T4Toolbox.VisualStudio.IntegrationTests.csproj
+++ b/test/T4Toolbox.VisualStudio.IntegrationTests/T4Toolbox.VisualStudio.IntegrationTests.csproj
@@ -9,15 +9,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="envdte">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="envdte80">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="envdte90">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="envdte" />
+    <Reference Include="envdte80" />
+    <Reference Include="envdte90" />
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility" />
     <Reference Include="Microsoft.VisualStudio.Text.Data" />
@@ -43,9 +37,7 @@
     <Reference Include="Microsoft.VisualStudio.TextTemplating.VSHost.15.0" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
-    <Reference Include="VSLangProj">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="VSLangProj" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/test/T4Toolbox.VisualStudio.Tests/T4Toolbox.VisualStudio.Tests.csproj
+++ b/test/T4Toolbox.VisualStudio.Tests/T4Toolbox.VisualStudio.Tests.csproj
@@ -9,9 +9,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <Reference Include="envdte">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
+    <Reference Include="envdte" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />

--- a/test/T4Toolbox.VisualStudio.Tests/T4Toolbox.VisualStudio.Tests.csproj
+++ b/test/T4Toolbox.VisualStudio.Tests/T4Toolbox.VisualStudio.Tests.csproj
@@ -15,6 +15,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" />
     <Reference Include="Microsoft.VisualStudio.Shell.15.0" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface" />


### PR DESCRIPTION
- Add `Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime` reference to `VisualStudio` projects to suppress error about missing interop type `IVsToolboxItemProvider2`.
- Suppress errors caused by the `ThreadHelper` obsoleted in version 15.3. It still works.
- Extract `EmbedInteropTypes` metadata from `Reference` elements in all projects into the `ItemDefinitionGroup` in the `T4Toolbox.Common.props` to reduce duplication.